### PR TITLE
修正opera安装插件后，无法正常清理tab页的问题

### DIFF
--- a/static/background.js
+++ b/static/background.js
@@ -370,7 +370,11 @@ function clearPinnedTabs() {
         return tab.id
       }
     })
-    chrome.tabs.remove(tabIds)
+
+    // opera doesn't remove pinned tabs, so lets first unpin
+    $.map(tabIds, function (tabId) {
+        chrome.tabs.update(tabId, {"pinned":false}, function(theTab){ chrome.tabs.remove(theTab.id); });
+    })
   })
 }
 


### PR DESCRIPTION
opera浏览器不能直接清理pinned tab,需要先unpin tab，然后再remove。